### PR TITLE
Actualizar gitignore auth.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules/
 /playwright/.cache/
 /playwright/.auth/
 .env
-auth.json
+/auth/auth.json
 /allure-reports/
 /allure-results/
 .DS_Store


### PR DESCRIPTION
Fixes #4 

**Arquitectura**: Actualización .gitignore para auth.json

**Descripción**:
Se actualiza el archivo .gitignore con la nueva ruta para auth.json. Este archivo no debería subirse al repositorio.

**Cambios en archivos**:
- .gitignore
   - Se actualiza la ruta a `/auth/auth.json `

**Cómo ejecutar**:
N/A

**Evidencia**:
`/auth/auth.js` está siendo ignorado.
<img width="573" height="499" alt="Screenshot 2026-04-20 at 4 22 04 p m" src="https://github.com/user-attachments/assets/edd41125-83b0-4c26-965a-ace975c48129" />

